### PR TITLE
Eggify the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Compiled files
+__pycache__/
+*.py[cod]
+
+# Packaging related files
+*.egg
+*.egg-info

--- a/pyment/pyment.py
+++ b/pyment/pyment.py
@@ -271,7 +271,7 @@ def get_files_from_dir(path, recursive=True, depth=0, file_ext='.py'):
     return file_list
 
 
-def main(files=[], input_style='auto', output_style='reST'):
+def run(source, files=[], input_style='auto', output_style='reST'):
     if input_style == 'auto':
         input_style = None
 
@@ -288,8 +288,7 @@ def main(files=[], input_style='auto', output_style='reST'):
         c.diff_to_file(os.path.basename(f) + ".patch", path, path)
 
 
-if __name__ == "__main__":
-
+def main():
     desc = 'Pyment %s - %s - %s - %s' % (__version__, __copyright__, __author__, __licence__)
     parser = argparse.ArgumentParser(description='Generates patches after (re)writing docstrings.')
     parser.add_argument('path', type=str,
@@ -308,4 +307,7 @@ if __name__ == "__main__":
 
     files = get_files_from_dir(source)
 
-    main(files, args.input, args.output)
+    run(source, files, args.input, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,11 @@ setup(name='Pyment',
       author_email='',
       url='https://github.com/dadadel/pyment',
       packages=['pyment'],
-     )
+      test_suite='tests.test_all',
+      entry_points={
+          'console_scripts': [
+              'pyment = pyment.pyment:main',
+          ],
+      },
+      )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import unittest
+
+current_dir = os.path.dirname(__file__)
+test_all = unittest.TestLoader().discover(current_dir)

--- a/tests/test_pyment.py
+++ b/tests/test_pyment.py
@@ -23,9 +23,13 @@ mydocs = '''        """This is a description of a method.
         @raise KeyError: raises exception
 
         """'''
-inifile = 'origin_test.py'
-jvdfile = 'javadoc_test.py'
-rstfile = 'rest_test.py'
+
+current_dir = os.path.dirname(__file__)
+absdir = lambda f: os.path.join(current_dir, f)
+
+inifile = absdir('origin_test.py')
+jvdfile = absdir('javadoc_test.py')
+rstfile = absdir('rest_test.py')
 
 
 class DocStringTests(unittest.TestCase):


### PR DESCRIPTION
I love `pyment.py` unfortunately you have to use the absolute path. Why not create a executable with setuptools. This way, you just have to run `python setup.py install` and voilà, you can run `pyment directory`.

I also added the test suite in setup.py, thus we can run `python setup.py test [TestCase[.test_case]]` to run the tests.

What do you think?
