### PR TITLE
Use entry_points to get a *.exe on windows

### DIFF
--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -6,7 +6,8 @@ import argparse
 import os
 
 from pyment import PyComment
-from pyment.pyment import __version__, __copyright__, __author__, __licence__
+from pyment import __version__, __copyright__, __author__, __licence__
+
 
 MAX_DEPTH_RECUR = 50
 ''' The maximum depth to reach while recursively exploring sub folders'''

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,10 @@ setup(name='Pyment',
       url='https://github.com/dadadel/pyment',
       packages=['pyment'],
       test_suite='tests.test_all',
-      scripts=['scripts/pyment'],
+      entry_points ={
+        'console_scripts': [
+            'pyment = pyment.pymentapp:main'
+        ]
+    },
+
       )


### PR DESCRIPTION
Without this, on windows, we only get a `scripts\pyment` file, which is not executeable under windows.