### PR TITLE
Fix raises in reST docs

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -21,6 +21,8 @@ import os
 import re
 from collections import defaultdict
 
+RAISES_NAME_REGEX = r'^([\w.]+)'
+
 
 def isin_alone(elems, line):
     """Check if an element from a list is the only element of a string.
@@ -918,7 +920,7 @@ class DocsTools(object):
             idx_p = self.get_key_index(data, 'raise')
             if idx_p >= 0:
                 idx_p += len(stl_param)
-                m = re.match(r'^([\w]+)', data[idx_p:].strip())
+                m = re.match(RAISES_NAME_REGEX, data[idx_p:].strip())
                 if m:
                     param = m.group(1)
                     start = idx_p + data[idx_p:].find(param)

--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1496,7 +1496,7 @@ class DocString(object):
                 line = data[i]
                 param = None
                 desc = ''
-                m = re.match(r'^\W*(\w+)[\W\s]+(\w[\s\w]+)', line.strip())
+                m = re.match(r'^\W*([\w.]+)[\W\s]+(\w[\s\w]+)', line.strip())
                 if m:
                     param = m.group(1).strip()
                     desc = m.group(2).strip()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -40,6 +40,24 @@ class IssuesTests(unittest.TestCase):
         d.parse_docs(txt)
         self.assertTrue(d.get_raw_docs() == expected)
 
+    def testIssue19(self):
+        txt = '''"""
+
+    :raises ValueError: on incorrect JSON
+    :raises requests.exceptions.HTTPError: on response error from server
+    """'''
+        expected = '''    """
+    
+
+
+    :raises ValueError: on incorrect JSON
+    :raises requests.exceptions.HTTPError: on response error from server
+
+    """'''
+        docs = ds.DocString('def test():', quotes='"""')
+        docs.parse_docs(txt)
+        self.assertTrue(docs.get_raw_docs() == expected)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
Fix issue https://github.com/dadadel/pyment/issues/19 when modules where incorrectly parsed in "raises" blocks.