### PR TITLE
Fix encoding name: utf-8 not utf8

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 __author__ = "A. Daouzli"
 __copyright__ = "Copyright 2012-2015, A. Daouzli"

--- a/pyment/pyment.py
+++ b/pyment/pyment.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 __author__ = "A. Daouzli"
 __copyright__ = "Copyright 2012-2015"

--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 import glob
 import argparse
@@ -41,7 +41,7 @@ def get_files_from_dir(path, recursive=True, depth=0, file_ext='.py'):
 
 def get_config(config_file):
     '''Get the configuration from a file.
-    
+
     @param config_file: the configuration file
     @return: the configuration
     @rtype: dict


### PR DESCRIPTION
The correct encoding name for python files is utf-8, not utf8.
Also, fix an empty line with whitespace.