### PR TITLE
Add  setup for pypi packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+description-file = README.md
+
+[bdist_wheel]
+universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description-file = README.rst
 
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,36 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from os import path
+
+curr_dir = path.abspath(path.dirname(__file__))
+
+with open(path.join(curr_dir, "README.rst")) as f:
+    long_desc = f.read()
+
 
 setup(name='Pyment',
-      version='0.3.2-dev',
-      description='',
+      version='0.3.2-dev3',
+      description='Generate automatically the doc from your code signature',
+      long_description=long_desc,
       author='A. Daouzli',
       author_email='',
+      license='GPLv3',
+      keywords="pyment numpydoc doc development generate auto",
+      classifiers = [
+          'Intended Audience :: Developers',
+          'Topic :: Documentation',
+          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.0',
+	  'Programming Language :: Python :: 3.1',
+	  'Programming Language :: Python :: 3.2',
+	  'Programming Language :: Python :: 3.3',
+  	  'Programming Language :: Python :: 3.4',
+ 	  'Programming Language :: Python :: 3.5',
+	  'Programming Language :: Python :: 3.6'
+          ],
       url='https://github.com/dadadel/pyment',
       packages=['pyment'],
       test_suite='tests.test_all',


### PR DESCRIPTION
I started the work towards adding `pyment` to `Pypi`, I am opening that PR as a work in progress (so anyone can comment/suggest on how to improve it) for issue #37 

As an example, here is how it currently looks (that will be improved): https://testpypi.python.org/pypi?:action=display&name=Pyment&version=0.3.2.dev3

Edit: Don't necessarily take into account the version in `setup.py` that should be reverted, it's just that for Pypi each upload has to have a different "name"