### PR TITLE
Use pip to install from Github in the Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,7 @@ Start quickly
 
 .. code-block:: sh
 
-        $ git clone https://github.com/dadadel/pyment.git  # or git@github.com:dadadel/pyment.git
-        $ cd pyment
-        $ python setup.py install
+        $ pip install git+https://github.com/dadadel/pyment.git
 
 - run from the command line:
 


### PR DESCRIPTION
Use pip to install from Github in the Readme.

It could also make sense to upload the package to PyPi...