### PR TITLE
Fix param parse when there's a function call in the default parameters

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1358,7 +1358,7 @@ class DocString(object):
                 if l[-1] == ':':
                     l = l[:-1].strip()
                 # retrieves the parameters
-                l = l[l.find('(') + 1:l.find(')')].strip()
+                l = l[l.find('(') + 1:l.rfind(')')].strip()
                 lst = [c.strip() for c in l.split(',')]
                 for e in lst:
                     if '=' in e:

--- a/tests/params.py
+++ b/tests/params.py
@@ -34,3 +34,7 @@ def func8(param1=123, param2=+456, param3="!:@"):
     pass
 
 
+def func9(param1=func1(), param2="stuff"):
+    pass
+
+

--- a/tests/params.py.patch.google.expected
+++ b/tests/params.py.patch.google.expected
@@ -114,3 +114,16 @@
      pass
  
  
+ def func9(param1=func1(), param2="stuff"):
++    """
++
++    Args:
++      param1:  (Default value = func1())
++      param2:  (Default value = "stuff")
++
++    Returns:
++
++    """
+     pass
+ 
+ 

--- a/tests/params.py.patch.javadoc.expected
+++ b/tests/params.py.patch.javadoc.expected
@@ -90,3 +90,13 @@
      pass
  
  
+ def func9(param1=func1(), param2="stuff"):
++    """
++
++    @param param1:  (Default value = func1())
++    @param param2:  (Default value = "stuff")
++
++    """
+     pass
+ 
+ 

--- a/tests/params.py.patch.numpydoc.expected
+++ b/tests/params.py.patch.numpydoc.expected
@@ -148,3 +148,20 @@
      pass
  
  
+ def func9(param1=func1(), param2="stuff"):
++    """
++
++    Parameters
++    ----------
++    param1 :
++         (Default value = func1())
++    param2 :
++         (Default value = "stuff")
++
++    Returns
++    -------
++
++    """
+     pass
+ 
+ 

--- a/tests/params.py.patch.reST.expected
+++ b/tests/params.py.patch.reST.expected
@@ -90,3 +90,13 @@
      pass
  
  
+ def func9(param1=func1(), param2="stuff"):
++    """
++
++    :param param1:  (Default value = func1())
++    :param param2:  (Default value = "stuff")
++
++    """
+     pass
+ 
+ 

--- a/tests/test_pyment_cases.py
+++ b/tests/test_pyment_cases.py
@@ -3,6 +3,7 @@
 import unittest
 import os
 import pyment.pyment as pym
+import re
 
 current_dir = os.path.dirname(__file__)
 absdir = lambda f: os.path.join(current_dir, f)
@@ -20,6 +21,10 @@ def get_expected_patch(self, name):
     except Exception as e:
         self.fail('Raised exception: "{0}"'.format(e))
     return expected
+
+
+def remove_diff_header(diff):
+    return re.sub('@@.+@@', '', diff)
 
 
 class FilesConversionTests(unittest.TestCase):
@@ -40,7 +45,7 @@ class FilesConversionTests(unittest.TestCase):
         p._parse()
         self.assertTrue(p.parsed)
         result = ''.join(p.diff())
-        self.assertTrue(result == expected)
+        self.assertTrue(remove_diff_header(result) == remove_diff_header(expected))
 
     def testCaseGenAllParamsGoogle(self):
         # The file has several functions with no or several parameters,
@@ -50,7 +55,7 @@ class FilesConversionTests(unittest.TestCase):
         p._parse()
         self.assertTrue(p.parsed)
         result = ''.join(p.diff())
-        self.assertTrue(result == expected)
+        self.assertTrue(remove_diff_header(result) == remove_diff_header(expected))
 
     def testCaseGenAllParamsNumpydoc(self):
         # The file has several functions with no or several parameters,
@@ -60,7 +65,7 @@ class FilesConversionTests(unittest.TestCase):
         p._parse()
         self.assertTrue(p.parsed)
         result = ''.join(p.diff())
-        self.assertTrue(result == expected)
+        self.assertTrue(remove_diff_header(result) == remove_diff_header(expected))
 
     def testCaseGenAllParamsJavadoc(self):
         # The file has several functions with no or several parameters,
@@ -70,7 +75,7 @@ class FilesConversionTests(unittest.TestCase):
         p._parse()
         self.assertTrue(p.parsed)
         result = ''.join(p.diff())
-        self.assertTrue(result == expected)
+        self.assertTrue(remove_diff_header(result) == remove_diff_header(expected))
 
     def testCaseNoGenDocsAlreadyReST(self):
         # The file has functions with already docstrings in reST format,


### PR DESCRIPTION
While modifying the tests I found that it was failing due to the header line counts... since those seem irrelevant to the test I added a function to remove those so tests can be added more easily.