### PR TITLE
Calculate positive relative end index for last section in NumpydocTools

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -219,6 +219,8 @@ class NumpydocTools(object):
         if init == -1:
             return []
         start, end = self.get_next_section_lines(data[init:])
+        if end == -1 and start != end:
+            end = len(data[init:])
 
         # get the spacing of line with key
         spaces = get_leading_spaces(data[init + start])

--- a/tests/issue49.py
+++ b/tests/issue49.py
@@ -1,0 +1,21 @@
+def func1(param1):
+    """Function to test issue #49
+
+    Parameters
+    ----------
+    param1 : object
+        Description of param1
+
+    Returns
+    -------
+    None
+        Description for return value
+
+    Raises
+    ------
+    AssertionError
+        Raises an error if run
+
+
+    """
+    assert False

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -131,7 +131,7 @@ class IssuesTests(unittest.TestCase):
     #     self.assertTrue(p.parsed)
     #     result = ''.join(p.diff())
     #     self.assertTrue(result == '')
-    #
+
     # def testIssue46(self):
     #     # Title: list, tuple, dict default param values are not parsed correctly
     #     # if a list/tuple/dict is given as default value for a parameter, the
@@ -160,6 +160,17 @@ class IssuesTests(unittest.TestCase):
     #     self.assertTrue(p.parsed)
     #     result = ''.join(p.diff())
     #     self.assertTrue(result == '')
+
+    def testIssue49(self):
+        # Title: If already numpydoc format, will remove the Raises section
+        # If the last section in a numpydoc docstring is a `Raises` section,
+        # it will be removed if the output format is also set to numpydoc
+        p = pym.PyComment(absdir('issue49.py'), output_style='numpydoc')
+        p._parse()
+        self.assertTrue(p.parsed)
+        result = ''.join(p.diff())
+        print(result)
+        self.assertTrue(result == '')
 
     def testIssue58(self):
         # Title: Comments after def statement not supported


### PR DESCRIPTION
To fix the issue one had to calculate the correct, positive relative end index in `NumpydocTools.get_list_key` instead of using -1 as end index.

But because there are more issues with already existing numpydoc which gets "converted" to numpydoc I left the test `tests/pyment_test_cases.FilesConversionTests.testCaseNoGenDocsAlreadyNumpydoc` untouched and I also did not modify the `tests/docs_already_numpydoc.py` file as this would also obfuscate the current issue with using "Raises" as last section.
However I added a dedicated Python file named `tests/issue_49.py` and showed my fix working by adding the corresponding unit test in `tests/test_issues.py`