### PR TITLE
Add type_stub param

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1164,7 +1164,7 @@ class DocString(object):
     """This class represents the docstring"""
 
     def __init__(self, elem_raw, spaces='', docs_raw=None, quotes="'''", input_style=None, output_style=None,
-                 first_line=False, trailing_space=True, **kwargs):
+                 first_line=False, trailing_space=True, type_stub=False, **kwargs):
         """
         :param elem_raw: raw data of the element (def or class).
         :param spaces: the leading whitespaces before the element
@@ -1181,11 +1181,14 @@ class DocString(object):
         :param trailing_space: if set, a trailing space will be inserted in places where the user
           should write a description
         :type trailing_space: boolean
+        :param type_stub: if set, an empty stub will be created for a parameter type
+        :type type_stub: boolean
 
         """
         self.dst = DocsTools()
         self.first_line = first_line
         self.trailing_space = ''
+        self.type_stub = type_stub
         if trailing_space:
             self.trailing_space = ' '
         if docs_raw and not input_style:
@@ -1763,9 +1766,10 @@ class DocString(object):
                         if p[2] is not None and len(p[2]) > 0:
                             raw += '\n'
                             raw += self.docs['out']['spaces'] + self.dst.get_key('type', 'out') + ' ' + p[0] + sep + p[2]
+                    if self.type_stub and (len(p) <= 2 or p[2] is None or len(p[2]) == 0):
                         raw += '\n'
-                    else:
-                        raw += '\n'
+                        raw += self.docs['out']['spaces'] + self.dst.get_key('type', 'out') + ' ' + p[0] + sep
+                    raw += '\n'
         return raw
 
     def _set_raw_raise(self, sep):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -45,7 +45,7 @@ googledocs = '''"""This is a Google style docs.
 
     Args:
       first(str): this is the first param
-      second(int): this is a second param
+      second: this is a second param
       third(str, optional): this is a third param
 
     Returns:
@@ -249,8 +249,11 @@ class DocStringTests(unittest.TestCase):
         d.parse_docs()
         self.assertTrue(len(d.docs['in']['params']) == 3)
         self.assertTrue(d.docs['in']['params'][0][0] == 'first')
+        self.assertTrue(d.docs['in']['params'][0][2] == 'str')
         self.assertTrue(d.docs['in']['params'][0][1].startswith('this is the first'))
+        self.assertFalse(d.docs['in']['params'][1][2])
         self.assertTrue(d.docs['in']['params'][2][1].startswith('this is a third'))
+        self.assertTrue(d.docs['in']['params'][2][2] == 'str')
 
     def testParsingGroupsDocsParams(self):
         doc = mygrpdocs
@@ -276,7 +279,9 @@ class DocStringTests(unittest.TestCase):
         d.parse_docs()
         self.assertTrue(len(d.docs['in']['params']) == 3)
         self.assertTrue(d.docs['in']['params'][0][0] == 'first')
+        self.assertTrue(d.docs['in']['params'][0][2] == 'array_like')
         self.assertTrue(d.docs['in']['params'][0][1].strip().startswith('the 1'))
+        self.assertFalse(d.docs['in']['params'][1][2])
         self.assertTrue(d.docs['in']['params'][2][1].strip().endswith("default 'value'"))
 
     def testParsingDocsRaises(self):
@@ -392,6 +397,46 @@ class DocStringTests(unittest.TestCase):
         self.assertTrue(d.docs['out']['params'][2] == ('third', '', None, '"value"'))
         # param's description
         self.assertTrue(d.docs['out']['params'][1][1].startswith("the 2"))
+
+    def testGeneratingDocsParamsTypeStubs(self):
+        doc = mydocs
+        d = docs.DocString(myelem, '    ', doc, type_stub=True)
+        d.parse_docs()
+        d.generate_docs()
+        self.assertTrue(':type second: ' in d.docs['out']['raw'])
+        self.assertTrue(':type third: ' in d.docs['out']['raw'])
+
+    def testGeneratingGoogleDocsParamsTypeStubs(self):
+        doc = googledocs
+        d = docs.DocString(myelem, '    ', doc, type_stub=True)
+        d.parse_docs()
+        d.generate_docs()
+        self.assertTrue(':type second: ' in d.docs['out']['raw'])
+
+    def testGeneratingGroupsDocsParamsTypeStubs(self):
+        doc = mygrpdocs
+        d = docs.DocString(myelem, '    ', doc, type_stub=True)
+        d.parse_docs()
+        d.generate_docs()
+        self.assertTrue(':type first: ' in d.docs['out']['raw'])
+        self.assertTrue(':type second: ' in d.docs['out']['raw'])
+        self.assertTrue(':type third: ' in d.docs['out']['raw'])
+
+    def testGeneratingGroups2DocsParamsTypeStubs(self):
+        doc = mygrpdocs2
+        d = docs.DocString(myelem, '    ', doc, type_stub=True)
+        d.parse_docs()
+        d.generate_docs()
+        self.assertTrue(':type first: ' in d.docs['out']['raw'])
+        self.assertTrue(':type second: ' in d.docs['out']['raw'])
+        self.assertTrue(':type third: ' in d.docs['out']['raw'])
+
+    def testGeneratingNumpyDocsParamsTypeStubs(self):
+        doc = mynumpydocs
+        d = docs.DocString(myelem, '    ', doc, type_stub=True)
+        d.parse_docs()
+        d.generate_docs()
+        self.assertTrue(':type second: ' in d.docs['out']['raw'])
 
     def testNoParam(self):
         elem = "    def noparam():"


### PR DESCRIPTION
Allows the creation of an empty stub for parameter type, similar to the description stub created. Includes test cases