### PR TITLE
Add google output/input to configuration file documentation

### DIFF
--- a/doc/sphinx/source/pyment.rst
+++ b/doc/sphinx/source/pyment.rst
@@ -169,13 +169,13 @@ The quotes used for the docstring limits.
 
 - **output_style**
 
-    *javadoc, reST, numpydoc, groups*
+    *javadoc, reST, numpydoc, google, groups*
 
 The output format for the docstring.
 
 - **input_style**
 
-    *auto, javadoc, reST, numpydoc, groups*
+    *auto, javadoc, reST, numpydoc, google, groups*
 
 The input format for the docstring interpretation. Set to **auto** if you want
 Pyment to autodetect for each docstring its format.


### PR DESCRIPTION
I just stumbled upon the missing "google" input/output format in the documentation for the configuration file.

I assume, this works (as the commandline settings indicate), so it is just missing documentation, right?

Thanks for this great tool!