### PR TITLE
Allow changing element indentation via config

### DIFF
--- a/doc/sphinx/source/pyment.rst
+++ b/doc/sphinx/source/pyment.rst
@@ -195,6 +195,11 @@ its docstring and the class its own.
 Set to **True** if you want only to convert existing docstring.
 So Pyment won't create missing docstrings.
 
+- **indent**
+
+    *Integer value (default is 2)*
+
+Change the amount of spaces used for indented elements.
 
 **Todo...**
 

--- a/pyment.conf
+++ b/pyment.conf
@@ -3,3 +3,4 @@ quotes = '''
 output_style = numpydoc
 input_style = auto
 init2class = false
+indent = 4

--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1226,7 +1226,7 @@ class DocString(object):
                 'return': None,
                 'rtype': None,
                 'raises': [],
-                'spaces': spaces + ' ' * 2
+                'spaces': spaces + ' ' * kwargs.get('indent', 2)
                 }
             }
         if '\t' in spaces:

--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -62,6 +62,8 @@ def get_config(config_file):
                     key, value = key.strip(), value.strip()
                     if key in ['init2class', 'first_line', 'convert_only']:
                         value = tobool(value)
+                    if key == 'indent':
+                        value = int(value)
                     config[key] = value
     return config
 


### PR DESCRIPTION
Providing 'indent' as a config option will change the indentation of docstring elements.

Especially useful for google style where
Args:
  Something

is currently indented with 2 spaces, which is 4 in most examples.