### PR TITLE
#90: fix no quotes starting docstring or quotes without docstring after signature

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1164,7 +1164,7 @@ class DocString(object):
     """This class represents the docstring"""
 
     def __init__(self, elem_raw, spaces='', docs_raw=None, quotes="'''", input_style=None, output_style=None,
-                 first_line=False, trailing_space=True, **kwargs):
+                 first_line=False, trailing_space=True, before_lim='', **kwargs):
         """
         :param elem_raw: raw data of the element (def or class).
         :param spaces: the leading whitespaces before the element
@@ -1181,9 +1181,11 @@ class DocString(object):
         :param trailing_space: if set, a trailing space will be inserted in places where the user
           should write a description
         :type trailing_space: boolean
+        :param before_lim: specify raw or unicode or format docstring type (ie. "r" for r'''... or "fu" for fu'''...)
 
         """
         self.dst = DocsTools()
+        self.before_lim = before_lim
         self.first_line = first_line
         self.trailing_space = ''
         if trailing_space:
@@ -1610,12 +1612,14 @@ class DocString(object):
             lst = self.dst.numpydoc.get_list_key(data, 'attr')
             # TODO do something with this?
 
-    def parse_docs(self, raw=None):
+    def parse_docs(self, raw=None, before_lim=''):
         """Parses the docstring
 
         :param raw: the data to parse if not internally provided (Default value = None)
+        :param before_lim: specify raw or unicode or format docstring type (ie. "r" for r'''... or "fu" for fu'''...)
 
         """
+        self.before_lim = before_lim
         if raw is not None:
             raw = raw.strip()
             if raw.startswith('"""') or raw.startswith("'''"):
@@ -1916,7 +1920,7 @@ class DocString(object):
         with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + l if i > 0 else l for i, l in enumerate(s.splitlines())])
 
         # sets the description section
-        raw = self.docs['out']['spaces'] + self.quotes
+        raw = self.docs['out']['spaces'] + self.before_lim + self.quotes
         desc = self.docs['out']['desc'].strip()
         if not desc or not desc.count('\n'):
             if not self.docs['out']['params'] and not self.docs['out']['return'] and not self.docs['out']['rtype'] and not self.docs['out']['raises']:

--- a/tests/issue90.py
+++ b/tests/issue90.py
@@ -1,0 +1,17 @@
+def foo():
+    __doc__ = """\
+    Foo"""
+
+
+def bar(param):
+    r"""this is a docstring
+    """
+
+
+def foobar():
+    u"""this is a docstring
+    """
+
+
+def no_docs():
+    something = '''bla bla bla'''

--- a/tests/issue90.py.patch
+++ b/tests/issue90.py.patch
@@ -1,0 +1,26 @@
+--- a/issue90.py
++++ b/issue90.py
+@@ -1,17 +1,21 @@
+ def foo():
++    """ """
+     __doc__ = """\
+     Foo"""
+ 
+ 
+ def bar(param):
+     r"""this is a docstring
++
++    :param param: 
++
+     """
+ 
+ 
+ def foobar():
+-    u"""this is a docstring
+-    """
++    u"""this is a docstring"""
+ 
+ 
+ def no_docs():
++    """ """
+     something = '''bla bla bla'''

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -227,6 +227,17 @@ class IssuesTests(unittest.TestCase):
         result = ''.join(p.diff())
         self.assertTrue(result == expected)
 
+    def testIssue90(self):
+        # Title: __doc__ is not well parsed
+        # If the line after function signature contains triple [double] quotes but is not a docstring
+        # it will be however considered as if it was and will have side effect.
+        p = pym.PyComment(absdir('issue90.py'))
+        p._parse()
+        f = open(absdir('issue90.py.patch'))
+        patch = f.read()
+        f.close()
+        self.assertEqual(''.join(p.diff()), patch)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
#90: fix parsing when after definition, docstring starts with r|u|f before delimiter or there's triple quotes without docstring