### PR TITLE
fix unwanted copy of next element of a docstring param without description #95

### DIFF
--- a/tests/issue95.py
+++ b/tests/issue95.py
@@ -1,0 +1,87 @@
+def func1(param1):
+    """Description
+
+    :param param1: 
+    :returns: the return value
+    """
+    pass
+
+
+def func2(param1):
+    """Description
+
+    :param param1: param's message
+    :return: the return value
+    """
+    pass
+
+
+def func3(param1):
+    """Description
+
+    :param param1:
+    :returns: the return value
+    """
+    pass
+
+
+def func4(param1, param2):
+    """Description
+
+    :param param1: 
+    :param param2: 
+    :returns: the return value
+    """
+    pass
+
+
+def func5(param1, param2):
+    """Description
+
+    :param param1: 
+    :type param1: str
+    :returns: the return value
+    """
+    pass
+
+
+def func6(param1, param2):
+    """Description
+
+    :param param1: parameter description
+    :param param2: 
+    :returns: the return value
+    """
+    pass
+
+
+def func7(param1):
+    """Description
+
+    Args:
+      param1: 
+    Returns:
+      the return value
+    """
+    pass
+
+
+def func8(param1):
+    """Description
+
+    :param param1: 
+    """
+    pass
+
+
+def func9(param1: str, param2):
+    """Description
+
+    :type param1: 
+    :param param2: 
+    :returns: foobar
+
+    """
+    pass
+
+

--- a/tests/issue95.py.patch
+++ b/tests/issue95.py.patch
@@ -1,0 +1,90 @@
+--- a/issue95.py
++++ b/issue95.py
+@@ -3,6 +3,7 @@
+ 
+     :param param1: 
+     :returns: the return value
++
+     """
+     pass
+ 
+@@ -11,7 +12,8 @@
+     """Description
+ 
+     :param param1: param's message
+-    :return: the return value
++    :returns: the return value
++
+     """
+     pass
+ 
+@@ -19,8 +21,9 @@
+ def func3(param1):
+     """Description
+ 
+-    :param param1:
++    :param param1: 
+     :returns: the return value
++
+     """
+     pass
+ 
+@@ -31,6 +34,7 @@
+     :param param1: 
+     :param param2: 
+     :returns: the return value
++
+     """
+     pass
+ 
+@@ -39,8 +43,9 @@
+     """Description
+ 
+     :param param1: 
+-    :type param1: str
++    :param param2: 
+     :returns: the return value
++
+     """
+     pass
+ 
+@@ -51,6 +56,7 @@
+     :param param1: parameter description
+     :param param2: 
+     :returns: the return value
++
+     """
+     pass
+ 
+@@ -58,10 +64,9 @@
+ def func7(param1):
+     """Description
+ 
+-    Args:
+-      param1: 
+-    Returns:
+-      the return value
++    :param param1: 
++    :returns: the return value
++
+     """
+     pass
+ 
+@@ -70,6 +75,7 @@
+     """Description
+ 
+     :param param1: 
++
+     """
+     pass
+ 
+@@ -77,7 +83,8 @@
+ def func9(param1: str, param2):
+     """Description
+ 
+-    :type param1: 
++    :param param1: 
++    :type param1: str
+     :param param2: 
+     :returns: foobar
+ 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -267,6 +267,15 @@ class IssuesTests(unittest.TestCase):
         f.close()
         self.assertEqual(''.join(p.diff()), patch)
 
+    def testIssue95(self):
+        # Title: When there's a parameter without description in reST, Pyment copies the whole next element
+        p = pym.PyComment(absdir('issue95.py'))
+        p._parse()
+        f = open(absdir('issue95.py.patch'))
+        patch = f.read()
+        f.close()
+        self.assertEqual(''.join(p.diff()), patch)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
This fixes the unwanted copy of a the next element to a first docstring's parameter without description.
It closes issues #95 and #34