### PR TITLE
#85: add support for type declaration in param statement for reST docstrings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.4.0:
         - add support to type hints (PEP 484)
         - stop supporting running Pyment with Python from version 2.7 to 3.5
-        - issues #34, #46, #69, #86, #93, #95, #97, #99
+        - issues #34, #46, #69, #85, #86, #93, #95, #97, #99
         - integrate PRs #96, #98
 
 0.3.4 - 2021/03/04:

--- a/tests/issue85.py
+++ b/tests/issue85.py
@@ -1,0 +1,58 @@
+def func(param_file, mask):
+    """
+    :param lxml.etree.ElementTree param_file: xml-element tree
+        obtained from the file.
+    :param str mask: Name of mask to be considered.
+    """
+    pass
+
+
+def func2(param1: str, param2):
+    """
+    :param str param1: description 1
+    :param str param2: description 2
+    :returns: description return
+    """
+    pass
+
+
+def func3(param1: str, param2):
+    """
+    :param param1: description 1 is
+        a multiline description
+    :type param1: str
+    :param str param2: description 2
+    :returns: description return
+    """
+    pass
+
+
+def func4(param1, param2):
+    """
+    :param param1: description 1
+    :type param1: str
+    :param str param2: description 2
+    :returns: description return
+    """
+    pass
+
+
+def func5(param1, param2):
+    """
+    :param int param1: description 1
+    :type param1: str
+    :param param2: description 2
+    :returns: description return
+    """
+    pass
+
+
+def func6(param1: list, param2):
+    """
+    :param int param1: description 1
+    :type param1: str
+    :param param2: description 2
+    :returns: description return
+    """
+    pass
+

--- a/tests/issue85.py.patch
+++ b/tests/issue85.py.patch
@@ -1,0 +1,83 @@
+--- a/issue85.py
++++ b/issue85.py
+@@ -1,58 +1,71 @@
+ def func(param_file, mask):
+     """
+-    :param lxml.etree.ElementTree param_file: xml-element tree
++
++    :param param_file: xml-element tree
+         obtained from the file.
+-    :param str mask: Name of mask to be considered.
++    :param mask: Name of mask to be considered.
++
+     """
+     pass
+ 
+ 
+ def func2(param1: str, param2):
+     """
+-    :param str param1: description 1
+-    :param str param2: description 2
++
++    :param param1: description 1
++    :type param1: str
++    :param param2: description 2
+     :returns: description return
++
+     """
+     pass
+ 
+ 
+ def func3(param1: str, param2):
+     """
++
+     :param param1: description 1 is
+         a multiline description
+     :type param1: str
+-    :param str param2: description 2
++    :param param2: description 2
+     :returns: description return
++
+     """
+     pass
+ 
+ 
+ def func4(param1, param2):
+     """
++
+     :param param1: description 1
+     :type param1: str
+-    :param str param2: description 2
++    :param param2: description 2
+     :returns: description return
++
+     """
+     pass
+ 
+ 
+ def func5(param1, param2):
+     """
+-    :param int param1: description 1
++
++    :param param1: description 1
+     :type param1: str
+     :param param2: description 2
+     :returns: description return
++
+     """
+     pass
+ 
+ 
+ def func6(param1: list, param2):
+     """
+-    :param int param1: description 1
+-    :type param1: str
++
++    :param param1: description 1
++    :type param1: list
+     :param param2: description 2
+     :returns: description return
++
+     """
+     pass
+ 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -236,6 +236,18 @@ class IssuesTests(unittest.TestCase):
         f.close()
         self.assertEqual(''.join(p.diff()), patch)
 
+    def testIssue85(self):
+        # Title: When converting from reST, parameter types are not handled correctly
+        # For reST, Sphinx allows to declare the type inside the parameter statement
+        # like this: `:param str name: description`
+        # Pyment should support this.
+        p = pym.PyComment(absdir('issue85.py'))
+        p._parse()
+        f = open(absdir('issue85.py.patch'))
+        patch = f.read()
+        f.close()
+        self.assertEqual(''.join(p.diff()), patch)
+
     def testIssue88(self):
         # Title: Not working on async functions
         # The async functions are not managed


### PR DESCRIPTION
This adds support for types declared inside a param statement for reST docstrings like in: `:param str name: description`.
However, Pyment will still continue to produce reST docstring where the type is not inside the param statement.
This closes #85 