### PR TITLE
Fix broken output when class docstring is missing

### DIFF
--- a/pyment/pyment.py
+++ b/pyment/pyment.py
@@ -107,6 +107,11 @@ class PyComment(object):
                     reading_element = 'end'
             elif (l.startswith('async def ') or l.startswith('def ') or l.startswith('class ')) and not reading_docs:
                 if self.ignore_private and l[l.find(' '):].strip().startswith("__"):
+                    # If we were still looking for the class docstring, stop
+                    # looking.  Otherwise we'll mistake this __dunder_method__
+                    # docstring for the class docstring and mess stuff up!
+                    # (See issue #83).
+                    waiting_docs = False
                     continue
                 reading_element = 'start'
                 elem = l

--- a/tests/issue83.py
+++ b/tests/issue83.py
@@ -1,0 +1,13 @@
+class Foo:
+    def __init__(self):
+        """Some init docstring"""
+        pass
+
+class Bar:
+    def __repr__(self):
+        """Some repr docstring"""
+        return 'Foo()'
+
+    def __init__(self):
+        """Some docstring"""
+        pass

--- a/tests/issue83.py.patch
+++ b/tests/issue83.py.patch
@@ -1,0 +1,14 @@
+--- a/issue83.py
++++ b/issue83.py
+@@ -1,9 +1,11 @@
+ class Foo:
++    """ """
+     def __init__(self):
+         """Some init docstring"""
+         pass
+ 
+ class Bar:
++    """ """
+     def __repr__(self):
+         """Some repr docstring"""
+         return 'Foo()'

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -236,6 +236,16 @@ class IssuesTests(unittest.TestCase):
         f.close()
         self.assertEqual(''.join(p.diff()), patch)
 
+    def testIssue83(self):
+        # Title: No docstring in class results in wrong indentation in __init__()
+        p = pym.PyComment(absdir('issue83.py'), ignore_private=True)
+        p.proceed()
+        with open(absdir('issue83.py.patch')) as f:
+           patch = f.read()
+        result = ''.join(p.diff())
+        print(result)
+        self.assertEqual(result, patch)
+
     def testIssue85(self):
         # Title: When converting from reST, parameter types are not handled correctly
         # For reST, Sphinx allows to declare the type inside the parameter statement


### PR DESCRIPTION
Fixes #83.

pyment was generating output with invalid indentation when all of the following conditions were met:

- ignore_private is `True` (the default on the command line)
- a class has no docstring
- the first method in that class is "private" (i.e. `__dunder__`) and has a docstring.

When skipping the private method header, the parser still had the waiting_docs flag set, and thus it was mistaking the method docstring for the class docstring.