### PR TITLE
docs: Fix a few typos

### DIFF
--- a/example.py
+++ b/example.py
@@ -49,7 +49,7 @@ class SomeClass(object):
     def method_numpy(self):
         """
         My numpydoc description of a kind
-        of very exhautive numpydoc format docstring.
+        of very exhaustive numpydoc format docstring.
 
         Parameters
         ----------

--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1373,7 +1373,7 @@ class DocString(object):
         self.quotes = quotes
 
     def __str__(self):
-        # for debuging
+        # for debugging
         txt = "\n\n** " + str(self.element['name'])
         txt += ' of type ' + str(self.element['deftype']) + ':'
         txt += str(self.docs['in']['desc']) + '\n'

--- a/pyment/pyment.py
+++ b/pyment/pyment.py
@@ -280,7 +280,7 @@ class PyComment(object):
         """Build the diff between original docstring and proposed docstring.
 
         :type which: int
-          -> -1 means all the dosctrings of the file
+          -> -1 means all the docstrings of the file
           -> >=0 means the index of the docstring to proceed (Default value = -1)
         :param source_path:  (Default value = '')
         :param target_path:  (Default value = '')

--- a/tests/issue88.py
+++ b/tests/issue88.py
@@ -12,7 +12,7 @@ async def async_func2():
 
 async def async_func3(param1, param2=None):
     """
-    somme comment
+    some comment
     :param param1: my parameter 1
     :param param2: my second param
     :return: nothing

--- a/tests/origin_test.py
+++ b/tests/origin_test.py
@@ -94,7 +94,7 @@ class MyTestClass(object):
         print ("this has elems in several lines")
 
     def my_method_full(self, first, second=None, third="value"):
-        '''The desctiption of method with 3 params and return value
+        '''The description of method with 3 params and return value
         on several lines
 
         @param first: the 1st param

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -163,7 +163,7 @@ class AppTests(unittest.TestCase):
         :param output_format: The output format - it adds the --output option, use None if auto is required
 
         :return: None
-        :raises: Assertion error if the expected rsult is not found
+        :raises: Assertion error if the expected result is not found
         """
 
         def assert_output(cmd_to_run, what, got, expected):
@@ -259,7 +259,7 @@ class AppTests(unittest.TestCase):
         The .patch and temporary files are removed at the end of the test.
 
         :param file_contents: write this into the temporary file
-        :param cmd_args: Arguments to pyment - do not put the '-w' argument here - it is trigged by overwrite_mode
+        :param cmd_args: Arguments to pyment - do not put the '-w' argument here - it is triggered by overwrite_mode
         :param overwrite_mode: set to True if in overwrite mode
         :param expected_file_contents: expected result - for a patch file ensure the filename is '-'. The '-'
             is replaced with the patch filename when overwrite_mode is False


### PR DESCRIPTION
There are small typos in:
- example.py
- pyment/docstring.py
- pyment/pyment.py
- tests/issue88.py
- tests/origin_test.py
- tests/test_app.py

Fixes:
- Should read `triggered` rather than `trigged`.
- Should read `some` rather than `somme`.
- Should read `result` rather than `rsult`.
- Should read `exhaustive` rather than `exhautive`.
- Should read `docstrings` rather than `dosctrings`.
- Should read `description` rather than `desctiption`.
- Should read `debugging` rather than `debuging`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md