### PR TITLE
Bump number of spaces in indent to 4 for google docstring format.

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1965,7 +1965,7 @@ class DocString(object):
                         raw += ' (Default value = ' + str(p[3]) + ')'
                 raw += '\n'
         elif self.dst.style['out'] == 'google':
-            spaces = ' ' * 2
+            spaces = ' ' * 4
             with_space = lambda s: '\n'.join([self.docs['out']['spaces'] +\
                                                     l.lstrip() if i > 0 else\
                                                     l for i, l in enumerate(s.splitlines())])


### PR DESCRIPTION
Increases hardcoded indent for google docstrings, however issue #18 suggest that this shoud be configurable so maybe this is not the ideal solution. If need be I can make it configurable, however, I'm not familiar with the project enough, should `indent` option from config file be used for this?