### PR TITLE
feat: Google indentation + more configurable parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 # Packaging related files
 *.egg
 *.egg-info
+
+# pycharm
+.idea/

--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1284,7 +1284,7 @@ class DocString(object):
     """This class represents the docstring"""
 
     def __init__(self, elem_raw, spaces='', docs_raw=None, quotes="'''", input_style=None, output_style=None,
-                 first_line=False, trailing_space=True, type_stub=False, before_lim='', **kwargs):
+                 first_line=False, trailing_space=True, type_stub=False, before_lim='', num_of_spaces=4, **kwargs):
         """
         :param elem_raw: raw data of the element (def or class).
         :param spaces: the leading whitespaces before the element
@@ -1304,6 +1304,8 @@ class DocString(object):
         :param type_stub: if set, an empty stub will be created for a parameter type
         :type type_stub: boolean
         :param before_lim: specify raw or unicode or format docstring type (ie. "r" for r'''... or "fu" for fu'''...)
+        :param num_of_spaces: the number of spaces to indent
+        :type num_of_spaces: integer
 
         """
         self.dst = DocsTools()
@@ -1371,6 +1373,7 @@ class DocString(object):
 
         self.parse_definition()
         self.quotes = quotes
+        self.num_of_spaces = num_of_spaces
 
     def __str__(self):
         # for debuging
@@ -1949,7 +1952,7 @@ class DocString(object):
         """
         raw = '\n'
         if self.dst.style['out'] == 'numpydoc':
-            spaces = ' ' * 4
+            spaces = ' ' * self.num_of_spaces
             with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + spaces +\
                                                     l.lstrip() if i > 0 else\
                                                     l for i, l in enumerate(s.splitlines())])
@@ -1965,7 +1968,7 @@ class DocString(object):
                         raw += ' (Default value = ' + str(p[3]) + ')'
                 raw += '\n'
         elif self.dst.style['out'] == 'google':
-            spaces = ' ' * 2
+            spaces = ' ' * self.num_of_spaces
             with_space = lambda s: '\n'.join([self.docs['out']['spaces'] +\
                                                     l.lstrip() if i > 0 else\
                                                     l for i, l in enumerate(s.splitlines())])
@@ -1973,7 +1976,7 @@ class DocString(object):
             for p in self.docs['out']['params']:
                 raw += self.docs['out']['spaces'] + spaces + p[0]
                 if p[2] is not None and len(p[2]) > 0:
-                    raw += '(' + p[2]
+                    raw += ' (' + p[2]
                     if len(p) > 3 and p[3] is not None:
                         raw += ', optional'
                     raw += ')'
@@ -2015,7 +2018,7 @@ class DocString(object):
                 raw += '\n'
                 if 'raise' in self.dst.numpydoc.get_mandatory_sections() or \
                         (self.docs['out']['raises'] and 'raise' in self.dst.numpydoc.get_optional_sections()):
-                    spaces = ' ' * 4
+                    spaces = ' ' * self.num_of_spaces
                     with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + spaces + l.lstrip() if i > 0 else l for i, l in enumerate(s.splitlines())])
                     raw += self.dst.numpydoc.get_key_section_header('raise', self.docs['out']['spaces'])
                     if len(self.docs['out']['raises']):
@@ -2028,7 +2031,7 @@ class DocString(object):
                 raw += '\n'
                 if 'raise' in self.dst.googledoc.get_mandatory_sections() or \
                         (self.docs['out']['raises'] and 'raise' in self.dst.googledoc.get_optional_sections()):
-                    spaces = ' ' * 2
+                    spaces = ' ' * self.num_of_spaces
                     with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + spaces + \
                                                             l.lstrip() if i > 0 else \
                                                             l for i, l in enumerate(s.splitlines())])
@@ -2068,7 +2071,7 @@ class DocString(object):
         raw = ''
         if self.dst.style['out'] == 'numpydoc':
             raw += '\n'
-            spaces = ' ' * 4
+            spaces = ' ' * self.num_of_spaces
             with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + spaces + l.lstrip() if i > 0 else l for i, l in enumerate(s.splitlines())])
             raw += self.dst.numpydoc.get_key_section_header('return', self.docs['out']['spaces'])
             if self.docs['out']['rtype']:
@@ -2097,7 +2100,7 @@ class DocString(object):
                 raw += '\n' + self.docs['out']['spaces'] + spaces + with_space(self.docs['out']['return']).strip() + '\n'
         elif self.dst.style['out'] == 'google':
             raw += '\n'
-            spaces = ' ' * 2
+            spaces = ' ' * self.num_of_spaces
             with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + spaces +\
                                                     l.lstrip() if i > 0 else\
                                                     l for i, l in enumerate(s.splitlines())])

--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1284,7 +1284,8 @@ class DocString(object):
     """This class represents the docstring"""
 
     def __init__(self, elem_raw, spaces='', docs_raw=None, quotes="'''", input_style=None, output_style=None,
-                 first_line=False, trailing_space=True, type_stub=False, before_lim='', num_of_spaces=4, **kwargs):
+                 first_line=False, trailing_space=True, type_stub=False, before_lim='', num_of_spaces=4,
+                 skip_empty=False, **kwargs):
         """
         :param elem_raw: raw data of the element (def or class).
         :param spaces: the leading whitespaces before the element
@@ -1306,6 +1307,8 @@ class DocString(object):
         :param before_lim: specify raw or unicode or format docstring type (ie. "r" for r'''... or "fu" for fu'''...)
         :param num_of_spaces: the number of spaces to indent
         :type num_of_spaces: integer
+        :param skip_empty: if set, will skip writing the params, returns, or raises if they are empty
+        :type skip_empty: boolean
 
         """
         self.dst = DocsTools()
@@ -1374,6 +1377,7 @@ class DocString(object):
         self.parse_definition()
         self.quotes = quotes
         self.num_of_spaces = num_of_spaces
+        self.skip_empty = skip_empty
 
     def __str__(self):
         # for debuging
@@ -1951,6 +1955,8 @@ class DocString(object):
 
         """
         raw = '\n'
+        if self.skip_empty and not self.docs['out']['params']:
+            return raw
         if self.dst.style['out'] == 'numpydoc':
             spaces = ' ' * self.num_of_spaces
             with_space = lambda s: '\n'.join([self.docs['out']['spaces'] + spaces +\
@@ -2013,6 +2019,8 @@ class DocString(object):
 
         """
         raw = ''
+        if self.skip_empty and not self.docs['out']['raises']:
+            return raw
         if self.dst.style['out'] == 'numpydoc':
             if 'raise' not in self.dst.numpydoc.get_excluded_sections():
                 raw += '\n'
@@ -2069,6 +2077,8 @@ class DocString(object):
 
         """
         raw = ''
+        if self.skip_empty and not self.docs['out']['return']:
+            return raw
         if self.dst.style['out'] == 'numpydoc':
             raw += '\n'
             spaces = ' ' * self.num_of_spaces

--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -2040,7 +2040,7 @@ class DocString(object):
                         for p in self.docs['out']['raises']:
                             raw += self.docs['out']['spaces'] + spaces
                             if p[0] is not None:
-                                raw += p[0] + sep
+                                raw += p[0] + ':' + sep
                             if p[1]:
                                 raw += p[1].strip()
                             raw += '\n'

--- a/pyment/pyment.py
+++ b/pyment/pyment.py
@@ -34,7 +34,8 @@ class PyComment(object):
 
     """
     def __init__(self, input_file, input_style=None, output_style='reST', quotes='"""', first_line=True,
-                 convert_only=False, config_file=None, ignore_private=False, num_of_spaces=4, **kwargs):
+                 convert_only=False, config_file=None, ignore_private=False, num_of_spaces=4, skip_empty=False,
+                 **kwargs):
         """Sets the configuration including the source to proceed and options.
 
         :param input_file: path name (file or folder)
@@ -47,6 +48,8 @@ class PyComment(object):
         :param convert_only: if set only existing docstring will be converted. No missing docstring will be created.
         :param config_file: if given configuration file for Pyment
         :param ignore_private: don't proceed the private methods/functions starting with __ (two underscores)
+        :param num_of_spaces: the number of spaces for a tab on output
+        :param skip_empty: if set, will not write the params, returns, or raises sections if they are empty
 
         """
         self.file_type = '.py'
@@ -65,6 +68,7 @@ class PyComment(object):
         self.config_file = config_file
         self.ignore_private = ignore_private
         self.num_of_spaces = num_of_spaces
+        self.skip_empty = skip_empty
         self.kwargs = kwargs
 
     def _parse(self):
@@ -130,6 +134,7 @@ class PyComment(object):
                               output_style=self.output_style,
                               first_line=self.first_line,
                               num_of_spaces=self.num_of_spaces,
+                              skip_empty=self.skip_empty,
                               **self.kwargs)
                 elem_list.append({'docs': e, 'location': (-i, -i)})
             else:

--- a/pyment/pyment.py
+++ b/pyment/pyment.py
@@ -34,7 +34,7 @@ class PyComment(object):
 
     """
     def __init__(self, input_file, input_style=None, output_style='reST', quotes='"""', first_line=True,
-                 convert_only=False, config_file=None, ignore_private=False, **kwargs):
+                 convert_only=False, config_file=None, ignore_private=False, num_of_spaces=4, **kwargs):
         """Sets the configuration including the source to proceed and options.
 
         :param input_file: path name (file or folder)
@@ -64,6 +64,7 @@ class PyComment(object):
         self.convert_only = convert_only
         self.config_file = config_file
         self.ignore_private = ignore_private
+        self.num_of_spaces = num_of_spaces
         self.kwargs = kwargs
 
     def _parse(self):
@@ -128,6 +129,7 @@ class PyComment(object):
                               input_style=self.input_style,
                               output_style=self.output_style,
                               first_line=self.first_line,
+                              num_of_spaces=self.num_of_spaces,
                               **self.kwargs)
                 elem_list.append({'docs': e, 'location': (-i, -i)})
             else:

--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -145,7 +145,7 @@ def main():
                         version=desc)
     parser.add_argument('-w', '--write', action='store_true', dest='overwrite',
                         default=False, help="Don't write patches. Overwrite files instead. If used with path '-' won\'t overwrite but write to stdout the new content instead of a patch/.")
-    parser.add_argument('-s', '--spaces', metavar='spaces', dest='spaces', default=4,
+    parser.add_argument('-s', '--spaces', metavar='spaces', dest='spaces', default=4, type=int,
                         help="The default number of spaces to use for indenting on output. Default is 4.")
     # parser.add_argument('-c', '--config', metavar='config_file',
     #                   dest='config', help='Configuration file')

--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -69,7 +69,8 @@ def get_config(config_file):
 
 
 def run(source, files=[], input_style='auto', output_style='reST', first_line=True, quotes='"""',
-        init2class=False, convert=False, config_file=None, ignore_private=False, overwrite=False, spaces=4):
+        init2class=False, convert=False, config_file=None, ignore_private=False, overwrite=False, spaces=4,
+        skip_empty=False):
     if input_style == 'auto':
         input_style = None
 
@@ -99,6 +100,7 @@ def run(source, files=[], input_style='auto', output_style='reST', first_line=Tr
                       ignore_private=ignore_private,
                       convert_only=convert,
                       num_of_spaces=spaces,
+                      skip_empty=skip_empty,
                       **config)
         c.proceed()
         if init2class:
@@ -147,6 +149,9 @@ def main():
                         default=False, help="Don't write patches. Overwrite files instead. If used with path '-' won\'t overwrite but write to stdout the new content instead of a patch/.")
     parser.add_argument('-s', '--spaces', metavar='spaces', dest='spaces', default=4, type=int,
                         help="The default number of spaces to use for indenting on output. Default is 4.")
+    parser.add_argument('-e', '--skip-empty', action='store_true', dest='skip_empty',
+                        default=False,
+                        help="Don't write params, returns, or raises sections if they are empty.")
     # parser.add_argument('-c', '--config', metavar='config_file',
     #                   dest='config', help='Configuration file')
 
@@ -167,7 +172,7 @@ def main():
         tobool(args.first_line), args.quotes,
         args.init2class, args.convert, config_file,
         tobool(args.ignore_private), overwrite=args.overwrite,
-        spaces=args.spaces)
+        spaces=args.spaces, skip_empty=args.skip_empty)
 
 
 if __name__ == "__main__":

--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -145,7 +145,7 @@ def main():
                         version=desc)
     parser.add_argument('-w', '--write', action='store_true', dest='overwrite',
                         default=False, help="Don't write patches. Overwrite files instead. If used with path '-' won\'t overwrite but write to stdout the new content instead of a patch/.")
-    parser.add_argument('-s', '--spaces', dest='spaces', default=4,
+    parser.add_argument('-s', '--spaces', metavar='spaces', dest='spaces', default=4,
                         help="The default number of spaces to use for indenting on output. Default is 4.")
     # parser.add_argument('-c', '--config', metavar='config_file',
     #                   dest='config', help='Configuration file')

--- a/pyment/pymentapp.py
+++ b/pyment/pymentapp.py
@@ -69,7 +69,7 @@ def get_config(config_file):
 
 
 def run(source, files=[], input_style='auto', output_style='reST', first_line=True, quotes='"""',
-        init2class=False, convert=False, config_file=None, ignore_private=False, overwrite=False):
+        init2class=False, convert=False, config_file=None, ignore_private=False, overwrite=False, spaces=4):
     if input_style == 'auto':
         input_style = None
 
@@ -98,6 +98,7 @@ def run(source, files=[], input_style='auto', output_style='reST', first_line=Tr
                       first_line=first_line,
                       ignore_private=ignore_private,
                       convert_only=convert,
+                      num_of_spaces=spaces,
                       **config)
         c.proceed()
         if init2class:
@@ -144,6 +145,8 @@ def main():
                         version=desc)
     parser.add_argument('-w', '--write', action='store_true', dest='overwrite',
                         default=False, help="Don't write patches. Overwrite files instead. If used with path '-' won\'t overwrite but write to stdout the new content instead of a patch/.")
+    parser.add_argument('-s', '--spaces', dest='spaces', default=4,
+                        help="The default number of spaces to use for indenting on output. Default is 4.")
     # parser.add_argument('-c', '--config', metavar='config_file',
     #                   dest='config', help='Configuration file')
 
@@ -163,7 +166,8 @@ def main():
     run(source, files, args.input, args.output,
         tobool(args.first_line), args.quotes,
         args.init2class, args.convert, config_file,
-        tobool(args.ignore_private), overwrite=args.overwrite)
+        tobool(args.ignore_private), overwrite=args.overwrite,
+        spaces=args.spaces)
 
 
 if __name__ == "__main__":

--- a/tests/docs_already_google.py
+++ b/tests/docs_already_google.py
@@ -3,13 +3,13 @@ def func1(param1):
     with 1 param
 
     Args:
-      param1(type): 1st parameter
+        param1 (type): 1st parameter
 
     Returns:
-      None
+        None
 
     Raises:
-      Exception: an exception
+        Exception: an exception
 
     """
     return None
@@ -20,8 +20,8 @@ def func2(param1, param2):
     with 2 params
 
     Args:
-      param1(type): 1st parameter
-      param2: 2nd parameter
+        param1 (type): 1st parameter
+        param2: 2nd parameter
 
     Returns:
 

--- a/tests/params.py.patch.google.expected
+++ b/tests/params.py.patch.google.expected
@@ -12,7 +12,7 @@
 +    """
 +
 +    Args:
-+      param1: 
++        param1: 
 +
 +    Returns:
 +
@@ -24,8 +24,8 @@
 +    """
 +
 +    Args:
-+      param1: 
-+      param2: 
++        param1: 
++        param2: 
 +
 +    Returns:
 +
@@ -37,9 +37,9 @@
 +    """
 +
 +    Args:
-+      param1: 
-+      param2: 
-+      param3: 
++        param1: 
++        param2: 
++        param3: 
 +
 +    Returns:
 +
@@ -51,7 +51,7 @@
 +    """
 +
 +    Args:
-+      param1:  (Default value = 123)
++        param1:  (Default value = 123)
 +
 +    Returns:
 +
@@ -63,8 +63,8 @@
 +    """
 +
 +    Args:
-+      param1: 
-+      param2:  (Default value = 123)
++        param1: 
++        param2:  (Default value = 123)
 +
 +    Returns:
 +
@@ -76,9 +76,9 @@
 +    """
 +
 +    Args:
-+      param1: 
-+      param2: 
-+      param3:  (Default value = 123)
++        param1: 
++        param2: 
++        param3:  (Default value = 123)
 +
 +    Returns:
 +
@@ -90,9 +90,9 @@
 +    """
 +
 +    Args:
-+      param1: 
-+      param2:  (Default value = None)
-+      param3:  (Default value = 123)
++        param1: 
++        param2:  (Default value = None)
++        param3:  (Default value = 123)
 +
 +    Returns:
 +
@@ -104,9 +104,9 @@
 +    """
 +
 +    Args:
-+      param1:  (Default value = 123)
-+      param2:  (Default value = +456)
-+      param3:  (Default value = "!:@")
++        param1:  (Default value = 123)
++        param2:  (Default value = +456)
++        param3:  (Default value = "!:@")
 +
 +    Returns:
 +
@@ -118,8 +118,8 @@
 +    """
 +
 +    Args:
-+      param1:  (Default value = func1())
-+      param2:  (Default value = "stuff")
++        param1:  (Default value = func1())
++        param2:  (Default value = "stuff")
 +
 +    Returns:
 +
@@ -131,8 +131,8 @@
 +    """
 +
 +    Args:
-+      param1:  (Default value = func1())
-+      param2:  (Default value = "stuff")
++        param1:  (Default value = func1())
++        param2:  (Default value = "stuff")
 +
 +    Returns:
 +


### PR DESCRIPTION
- makes Google indentation 4 spaces (with the option to change it on the cli or for any other output format style)
- adds the ability to skip adding empty parameters, raises, or returns with cli flag
- adds `.idea` to `.gitignore` for pycharm users
- adds missing `:` to when adding the raises for Google docstring format

Fixes issue: https://github.com/dadadel/pyment/issues/18