### PR TITLE
Add multiline description support, more helpful error messages

### DIFF
--- a/pyment/docstring.py
+++ b/pyment/docstring.py
@@ -1984,7 +1984,7 @@ class DocString(object):
                 raw += '\n'
         elif self.dst.style['out'] == 'groups':
             pass
-        else:
+        else:  # sphinx/reST style
             with_space = lambda s: '\n'.join(
                 [self.docs['out']['spaces'] + l if i > 0 else l for i, l in enumerate(s.splitlines())]
             )


### PR DESCRIPTION
I've encountered some cases that don't tell the user what to fix. This catches the exception and localizes the error.

It also supports multi-line comments.

Example:

```python
def myfunc():
    """Text
    
    :param myparam1: text followed by an empty line (will throw an error)
    
    :param myparam2: more text
        with an extra line (will work fine)
    :param myparam3 which has no closing colon (will throw an error)`
    """
    pass
```

